### PR TITLE
[Task #7] Change gosearch to OOP style

### DIFF
--- a/07/cmd/gosearch/documents.json
+++ b/07/cmd/gosearch/documents.json
@@ -1,0 +1,37 @@
+[
+  {
+    "ID": 0,
+    "URL": "https://go.dev/solutions#case-studies",
+    "Title": "Why Go - go.dev"
+  },
+  {
+    "ID": 0,
+    "URL": "https://go.dev/learn",
+    "Title": "Getting Started - go.dev"
+  },
+  {
+    "ID": 0,
+    "URL": "https://go.dev",
+    "Title": "go.dev"
+  },
+  {
+    "ID": 0,
+    "URL": "https://go.dev/",
+    "Title": "go.dev"
+  },
+  {
+    "ID": 0,
+    "URL": "https://go.dev/solutions",
+    "Title": "Why Go - go.dev"
+  },
+  {
+    "ID": 0,
+    "URL": "https://go.dev/about",
+    "Title": "About - go.dev"
+  },
+  {
+    "ID": 0,
+    "URL": "https://go.dev/solutions#use-cases",
+    "Title": "Why Go - go.dev"
+  }
+]

--- a/07/cmd/gosearch/main.go
+++ b/07/cmd/gosearch/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/romanserikov/thinknetica-go/07/pkg/crawler"
+	"github.com/romanserikov/thinknetica-go/07/pkg/crawler/spider"
+	"github.com/romanserikov/thinknetica-go/07/pkg/engine"
+)
+
+// Service - struct for gosearch service
+type Service struct {
+	engine  *engine.Service
+	crawler crawler.Scanner
+	sites   []string
+	depth   int
+}
+
+func main() {
+	gosearch := New()
+	gosearch.Start()
+}
+
+// New - creates new gosearch service
+func New() *Service {
+	crawler := spider.New()
+
+	return &Service{
+		engine:  engine.New(crawler, "documents.json"),
+		crawler: crawler,
+		sites:   []string{"https://go.dev"},
+		depth:   2,
+	}
+}
+
+// Start - starts gosearch service
+func (s *Service) Start() {
+	if err := s.engine.Start(s.sites, s.depth); err != nil {
+		log.Println(err)
+		return
+	}
+
+	for {
+		fmt.Println("Please, enter search request. Type exit to stop.")
+
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		input := scanner.Text()
+
+		if input == "exit" {
+			fmt.Println("See you next time.")
+			return
+		}
+
+		words := strings.Split(input, " ")
+		response := s.engine.Search(words)
+
+		if len(response) == 0 {
+			fmt.Println("Sorry, nothing found.")
+			continue
+		}
+
+		fmt.Println("Results:")
+		for url, title := range response {
+			fmt.Printf("  * %s - %s\n", url, title)
+		}
+	}
+}

--- a/07/go.mod
+++ b/07/go.mod
@@ -1,0 +1,5 @@
+module github.com/romanserikov/thinknetica-go/07
+
+go 1.13
+
+require golang.org/x/net v0.0.0-20201110031124-69a78807bb2b

--- a/07/pkg/bst/bst.go
+++ b/07/pkg/bst/bst.go
@@ -1,0 +1,76 @@
+package bst
+
+// Tree - binary search tree
+// based on https://github.com/hardcode-dev/go-core/blob/master/5-ds/bst/bst.go
+type Tree struct {
+	root      *Element
+	currentID uint
+}
+
+// Element - tree element
+type Element struct {
+	left, right *Element
+	Value       *Document
+}
+
+// Document - stores information about web page
+type Document struct {
+	ID    uint
+	URL   string
+	Title string
+}
+
+// Insert document in Tree, autoincrements currentID, returns id of inserted document
+func (t *Tree) Insert(doc *Document) uint {
+	doc.ID = t.currentID
+	t.currentID++
+
+	e := &Element{Value: doc}
+	if t.root == nil {
+		t.root = e
+		return doc.ID
+	}
+
+	return t.insert(t.root, e)
+}
+
+// insert recursive
+func (t *Tree) insert(node, new *Element) uint {
+	if new.Value.ID < node.Value.ID {
+		if node.left == nil {
+			node.left = new
+			return new.Value.ID
+		}
+
+		return t.insert(node.left, new)
+	}
+
+	if node.right == nil {
+		node.right = new
+		return new.Value.ID
+	}
+
+	return t.insert(node.right, new)
+}
+
+// Search for document in tree
+func (t *Tree) Search(id uint) *Document {
+	return search(t.root, id)
+}
+
+// search recursive
+func search(el *Element, id uint) *Document {
+	if el == nil {
+		return nil
+	}
+
+	if el.Value.ID == id {
+		return el.Value
+	}
+
+	if el.Value.ID < id {
+		return search(el.right, id)
+	}
+
+	return search(el.left, id)
+}

--- a/07/pkg/crawler/crawler.go
+++ b/07/pkg/crawler/crawler.go
@@ -1,0 +1,6 @@
+package crawler
+
+// Scanner - interface
+type Scanner interface {
+	Scan(url string, depth int) (data map[string]string, err error)
+}

--- a/07/pkg/crawler/spider/spider.go
+++ b/07/pkg/crawler/spider/spider.go
@@ -1,0 +1,111 @@
+// Package spider реализует сканер содержимого веб-сайтов.
+// Пакет позволяет получить список ссылок и заголовков страниц внутри веб-сайта по его URL.
+package spider
+
+import (
+	"net/http"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// Service - служба поискового робота.
+type Service struct{}
+
+// New - констрктор службы поискового робота.
+func New() *Service {
+	s := Service{}
+	return &s
+}
+
+// Scan осуществляет рекурсивный обход ссылок сайта, указанного в URL,
+// с учётом глубины перехода по ссылкам, переданной в depth.
+func (s *Service) Scan(url string, depth int) (map[string]string, error) {
+	data := make(map[string]string)
+
+	parse(url, url, depth, data)
+
+	return data, nil
+}
+
+// parse рекурсивно обходит ссылки на странице, переданной в url.
+// Глубина рекурсии задаётся в depth.
+// Каждая найденная ссылка записывается в ассоциативный массив
+// data вместе с названием страницы.
+func parse(url, baseurl string, depth int, data map[string]string) error {
+	if depth == 0 {
+		return nil
+	}
+
+	response, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	page, err := html.Parse(response.Body)
+	if err != nil {
+		return err
+	}
+
+	data[url] = pageTitle(page)
+
+	links := pageLinks(nil, page)
+	for _, link := range links {
+		// ссылка уже отсканирована
+		if data[link] != "" {
+			continue
+		}
+		// ссылка содержит базовый url полностью
+		if strings.HasPrefix(link, baseurl) {
+			parse(link, baseurl, depth-1, data)
+		}
+		// относительная ссылка
+		if strings.HasPrefix(link, "/") && len(link) > 1 {
+			next := baseurl + link[1:]
+			parse(next, baseurl, depth-1, data)
+		}
+	}
+
+	return nil
+}
+
+// pageTitle осуществляет рекурсивный обход HTML-страницы и возвращает значение элемента <tittle>.
+func pageTitle(n *html.Node) string {
+	var title string
+	if n.Type == html.ElementNode && n.Data == "title" && n.FirstChild != nil {
+		return n.FirstChild.Data
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		title = pageTitle(c)
+		if title != "" {
+			break
+		}
+	}
+	return title
+}
+
+// pageLinks рекурсивно сканирует узлы HTML-страницы и возвращает все найденные ссылки без дубликатов.
+func pageLinks(links []string, n *html.Node) []string {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for _, a := range n.Attr {
+			if a.Key == "href" {
+				if !sliceContains(links, a.Val) {
+					links = append(links, a.Val)
+				}
+			}
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		links = pageLinks(links, c)
+	}
+	return links
+}
+
+// sliceContains возвращает true если массив содержит переданное значение
+func sliceContains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}

--- a/07/pkg/engine/engine.go
+++ b/07/pkg/engine/engine.go
@@ -14,37 +14,27 @@ import (
 
 // Service - struct for search engine
 type Service struct {
-	indexer   *index.Service
-	crawler   crawler.Scanner
-	cacheFile string
+	indexer *index.Service
+	crawler crawler.Scanner
+	cache   string
 }
 
 // New - creates new engine service
-func New(crawler crawler.Scanner, cachefile string) *Service {
+func New(crawler crawler.Scanner, cache string) *Service {
 	return &Service{
-		crawler:   crawler,
-		cacheFile: cachefile,
+		crawler: crawler,
+		cache:   cache,
 	}
 }
 
-// Start - starts the search engine
-func (s *Service) Start(sites []string, depth int) error {
-	if fileExists(s.cacheFile) {
-		if err := s.LoadCache(); err != nil {
-			return err
-		}
-
-		go s.Sync(sites, depth)
-		return nil
-	}
-
-	s.Sync(sites, depth)
-	return nil
+// HasCache - checks if cache file exists
+func (s *Service) HasCache() bool {
+	return fileExists(s.cache)
 }
 
 // LoadCache - loads cache from local file
 func (s *Service) LoadCache() error {
-	file, err := ioutil.ReadFile(s.cacheFile)
+	file, err := ioutil.ReadFile(s.cache)
 	if err != nil {
 		return err
 	}
@@ -83,7 +73,7 @@ func (s *Service) Sync(sites []string, depth int) {
 		})
 	}
 
-	saveDocuments(s.cacheFile, docs)
+	saveDocuments(s.cache, docs)
 
 	ind := index.New()
 	ind.BuildIndex(data)

--- a/07/pkg/engine/engine.go
+++ b/07/pkg/engine/engine.go
@@ -1,0 +1,164 @@
+package engine
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/romanserikov/thinknetica-go/07/pkg/bst"
+	"github.com/romanserikov/thinknetica-go/07/pkg/crawler"
+	"github.com/romanserikov/thinknetica-go/07/pkg/index"
+)
+
+// Service - struct for search engine
+type Service struct {
+	indexer   *index.Service
+	crawler   crawler.Scanner
+	cacheFile string
+}
+
+// New - creates new engine service
+func New(crawler crawler.Scanner, cachefile string) *Service {
+	return &Service{
+		crawler:   crawler,
+		cacheFile: cachefile,
+	}
+}
+
+// Start - starts the search engine
+func (s *Service) Start(sites []string, depth int) error {
+	if fileExists(s.cacheFile) {
+		if err := s.LoadCache(); err != nil {
+			return err
+		}
+
+		go s.Sync(sites, depth)
+		return nil
+	}
+
+	s.Sync(sites, depth)
+	return nil
+}
+
+// LoadCache - loads cache from local file
+func (s *Service) LoadCache() error {
+	file, err := ioutil.ReadFile(s.cacheFile)
+	if err != nil {
+		return err
+	}
+
+	var docs []bst.Document
+	if err := json.Unmarshal(file, &docs); err != nil {
+		return err
+	}
+
+	data := make(map[string]string)
+	for _, doc := range docs {
+		data[doc.URL] = doc.Title
+	}
+
+	ind := index.New()
+	ind.BuildIndex(data)
+
+	s.indexer = ind
+
+	return nil
+}
+
+// Sync - get fresh data from crawler, save it to local file and update indexed documents
+func (s *Service) Sync(sites []string, depth int) {
+	data, err := sync(s.crawler, sites, depth)
+	if err != nil {
+		log.Println("error occured while getting new data", err)
+		return
+	}
+
+	var docs []bst.Document
+	for url, title := range data {
+		docs = append(docs, bst.Document{
+			URL:   url,
+			Title: title,
+		})
+	}
+
+	saveDocuments(s.cacheFile, docs)
+
+	ind := index.New()
+	ind.BuildIndex(data)
+
+	s.indexer = ind
+}
+
+// Search - search for result
+func (s *Service) Search(words []string) map[string]string {
+	docIDs := make(map[uint]struct{})
+	for _, word := range words {
+		documentIDs, ok := s.indexer.Index[strings.ToLower(word)]
+		if !ok {
+			continue
+		}
+
+		for id := range documentIDs {
+			docIDs[id] = struct{}{}
+		}
+	}
+
+	response := make(map[string]string)
+	for id := range docIDs {
+		if doc := s.indexer.Documents.Search(id); doc != nil {
+			response[doc.URL] = doc.Title
+		}
+	}
+
+	return response
+}
+
+// search - search for new data from sites
+func sync(scanner crawler.Scanner, sites []string, depth int) (map[string]string, error) {
+	data := make(map[string]string)
+
+	for _, site := range sites {
+		scanned, err := scanner.Scan(site, depth)
+		if err != nil {
+			return nil, err
+		}
+
+		for url, title := range scanned {
+			data[url] = title
+		}
+	}
+
+	return data, nil
+}
+
+// saveDocuments - saves data to local cache
+func saveDocuments(filename string, docs []bst.Document) {
+	f, err := os.Create(filename)
+	if err != nil {
+		log.Println("error while creating cache", err)
+		return
+	}
+	defer f.Close()
+
+	data, err := json.MarshalIndent(docs, "", "  ")
+	if err != nil {
+		log.Println("error while creating cache", err)
+		return
+	}
+
+	if _, err := f.Write(data); err != nil {
+		log.Println("error while creating cache", err)
+		return
+	}
+}
+
+// fileExists - checks if file exists
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/07/pkg/index/index.go
+++ b/07/pkg/index/index.go
@@ -1,0 +1,55 @@
+package index
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/romanserikov/thinknetica-go/07/pkg/bst"
+)
+
+// Service - stores search index, documents and documentID counter
+type Service struct {
+	Index     Index
+	Documents *bst.Tree
+	LastID    uint
+}
+
+// Index - Inverted index for fast document search
+// Store unique document ids for each word
+type Index map[string]map[uint]struct{}
+
+// New - creates new index Service
+func New() *Service {
+	return &Service{
+		Index:     make(Index),
+		Documents: new(bst.Tree),
+	}
+}
+
+// BuildIndex - takes raw documents from spider package and build index on it.
+// Stores Index and Documents in Service object
+func (s *Service) BuildIndex(documents map[string]string) {
+	if len(documents) == 0 {
+		fmt.Println("no documents for indexing")
+		return
+	}
+
+	for url, title := range documents {
+		id := s.Documents.Insert(&bst.Document{
+			URL:   url,
+			Title: title,
+		})
+
+		words := strings.Split(title, " ")
+
+		for _, w := range words {
+			word := strings.ToLower(w)
+
+			if _, ok := s.Index[word]; !ok {
+				s.Index[word] = make(map[uint]struct{})
+			}
+
+			s.Index[word][id] = struct{}{}
+		}
+	}
+}


### PR DESCRIPTION
Переписать поисковик в ООП-стиле

Поскольку наш поисковик хранит состояние, то логичнее представить его как объект.


Разработать структуру данных для сервера поисковика. Предлагается создать отдельный исполняемый пакет, в котором была бы разработана структура данных и методы для приложения-сервера. 

То есть отдельный пакет именно для службы поисковика. Этот исполняемый пакет становится ядром системы и точкой входа для пользователя: он должен вызывать сканирование сайтов, обработку поисковых запросов из консоли и т.д.


Переписать функции поисковика в виде методов. Функции сканирования документов, работы с хранилищем документов и обработки поисковых запросов должны быть реализованы в виде методов сервера. Естественным образом должны исчезнуть все глобальные переменные